### PR TITLE
Add sbin path to satisfy brew doctor

### DIFF
--- a/init.fish
+++ b/init.fish
@@ -1,9 +1,13 @@
-set -l linuxbrew_path "$HOME/.linuxbrew/bin"
+set -l linuxbrew_bin_path "$HOME/.linuxbrew/bin"
+set -l linuxbrew_sbin_path "$HOME/.linuxbrew/sbin"
 set -l linuxbrew_manpath "$HOME/.linuxbrew/share/man"
 set -l linuxbrew_infopath "$HOME/.linuxbrew/share/info"
 
-contains -- $linuxbrew_path $PATH
-  or set -gx PATH $linuxbrew_path $PATH
+contains -- $linuxbrew_bin_path $PATH
+  or set -gx PATH $linuxbrew_bin_path $PATH
+
+contains -- $linuxbrew_sbin_path $PATH
+  or set -gx PATH $linuxbrew_sbin_path $PATH
 
 contains -- $linuxbrew_manpath $MANPATH
   or set -gx MANPATH $linuxbrew_manpath $MANPATH


### PR DESCRIPTION
This would be nice for the sake of completeness and to satisfy `brew doctor`:

````
$ brew doctor                                                                                                                                                       
Please note that these warnings are just used to help the Homebrew maintainers
with debugging if you file an issue. If everything you use Homebrew for is
working fine: please don't worry and just ignore them. Thanks!

Warning: Homebrew's sbin was not found in your PATH but you have installed
formulae that put executables in /home/user/.linuxbrew/sbin.
Consider setting the PATH for example like so
    echo 'export PATH="/home/user/.linuxbrew/sbin:$PATH"' >> ~/.bash_profile
````